### PR TITLE
Add target to Module.sol

### DIFF
--- a/contracts/core/Modifier.sol
+++ b/contracts/core/Modifier.sol
@@ -64,7 +64,7 @@ abstract contract Modifier is Module {
     /// @dev Disables a module on the modifier
     /// @param prevModule Module that pointed to the module to be removed in the linked list
     /// @param module Module to be removed
-    /// @notice This can only be called by the avatar
+    /// @notice This can only be called by the owner
     function disableModule(address prevModule, address module)
         public
         onlyOwner
@@ -81,7 +81,7 @@ abstract contract Modifier is Module {
 
     /// @dev Enables a module that can add transactions to the queue
     /// @param module Address of the module to be enabled
-    /// @notice This can only be called by the avatar
+    /// @notice This can only be called by the owner
     function enableModule(address module) public onlyOwner {
         require(
             module != address(0) && module != SENTINEL_MODULES,

--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -11,9 +11,13 @@ import "../guard/Guardable.sol";
 abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
     /// @dev Emitted each time the avatar is set.
     event AvatarSet(address indexed previousAvatar, address indexed newAvatar);
+    /// @dev Emitted each time the Target is set.
+    event TargetSet(address indexed previousTarget, address indexed newTarget);
 
-    /// @dev Address that this module will pass transactions to.
+    /// @dev Address that will ultimately execute function calls.
     address public avatar;
+    /// @dev Address that this module will pass transactions to.
+    address public target;
 
     /// @dev Sets the avatar to a new avatar (`newAvatar`).
     /// @notice Can only be called by the current owner.
@@ -21,6 +25,14 @@ abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
         address previousAvatar = avatar;
         avatar = _avatar;
         emit AvatarSet(previousAvatar, _avatar);
+    }
+
+    /// @dev Sets the target to a new target (`newTarget`).
+    /// @notice Can only be called by the current owner.
+    function setTarget(address _target) public onlyOwner {
+        address previousTarget = target;
+        target = _target;
+        emit TargetSet(previousTarget, _target);
     }
 
     /// @dev Passes a transaction to be executed by the avatar.
@@ -53,7 +65,7 @@ abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
                 address(0)
             );
         }
-        success = IAvatar(avatar).execTransactionFromModule(
+        success = IAvatar(target).execTransactionFromModule(
             to,
             value,
             data,
@@ -65,7 +77,7 @@ abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
         return success;
     }
 
-    /// @dev Passes a transaction to be executed by the avatar and returns data.
+    /// @dev Passes a transaction to be executed by the target and returns data.
     /// @notice Can only be called by this contract.
     /// @param to Destination address of module transaction.
     /// @param value Ether value of module transaction.
@@ -95,7 +107,7 @@ abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
                 address(0)
             );
         }
-        (success, returnData) = IAvatar(avatar)
+        (success, returnData) = IAvatar(target)
             .execTransactionFromModuleReturnData(to, value, data, operation);
         if (guard != address(0)) {
             IGuard(guard).checkAfterExecution(bytes32("0x"), success);

--- a/contracts/test/TestModifier.sol
+++ b/contracts/test/TestModifier.sol
@@ -23,8 +23,8 @@ contract TestModifier is Modifier {
         bool success
     );
 
-    constructor(address _avatar) {
-        bytes memory initParams = abi.encode(_avatar);
+    constructor(address _avatar, address _target) {
+        bytes memory initParams = abi.encode(_avatar, _target);
         setUp(initParams);
     }
 
@@ -74,8 +74,12 @@ contract TestModifier is Modifier {
 
     function setUp(bytes memory initializeParams) public override {
         __Ownable_init();
-        address _avatar = abi.decode(initializeParams, (address));
+        (address _avatar, address _target) = abi.decode(
+            initializeParams,
+            (address, address)
+        );
         avatar = _avatar;
+        target = _target;
         initialized = true;
     }
 }

--- a/contracts/test/TestModule.sol
+++ b/contracts/test/TestModule.sol
@@ -6,8 +6,8 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../core/Module.sol";
 
 contract TestModule is Module {
-    constructor(address _avatar) {
-        bytes memory initParams = abi.encode(_avatar);
+    constructor(address _avatar, address _target) {
+        bytes memory initParams = abi.encode(_avatar, _target);
         setUp(initParams);
     }
 
@@ -56,8 +56,12 @@ contract TestModule is Module {
 
     function setUp(bytes memory initializeParams) public override {
         __Ownable_init();
-        address _avatar = abi.decode(initializeParams, (address));
+        (address _avatar, address _target) = abi.decode(
+            initializeParams,
+            (address, address)
+        );
         avatar = _avatar;
+        target = _target;
         initialized = true;
     }
 }

--- a/test/02_Module.spec.ts
+++ b/test/02_Module.spec.ts
@@ -12,7 +12,7 @@ describe("Module", async () => {
     const avatar = await Avatar.deploy();
     const iAvatar = await hre.ethers.getContractAt("IAvatar", avatar.address);
     const Module = await hre.ethers.getContractFactory("TestModule");
-    const module = await Module.deploy(iAvatar.address);
+    const module = await Module.deploy(iAvatar.address, iAvatar.address);
     await avatar.enableModule(module.address);
     const Guard = await hre.ethers.getContractFactory("TestGuard");
     const guard = await Guard.deploy(module.address);
@@ -54,6 +54,28 @@ describe("Module", async () => {
       const { iAvatar, module } = await setupTests();
       await expect(module.setAvatar(user2.address))
         .to.emit(module, "AvatarSet")
+        .withArgs(iAvatar.address, user2.address);
+    });
+  });
+
+  describe("setTarget", async () => {
+    it("reverts if caller is not the owner", async () => {
+      const { iAvatar, module } = await setupTests();
+      await module.transferOwnership(user2.address);
+      await expect(module.setTarget(iAvatar.address)).to.be.revertedWith(
+        "Ownable: caller is not the owner"
+      );
+    });
+
+    it("allows owner to set avatar", async () => {
+      const { iAvatar, module } = await setupTests();
+      await expect(module.setTarget(iAvatar.address));
+    });
+
+    it("emits previous owner and new owner", async () => {
+      const { iAvatar, module } = await setupTests();
+      await expect(module.setTarget(user2.address))
+        .to.emit(module, "TargetSet")
         .withArgs(iAvatar.address, user2.address);
     });
   });

--- a/test/03_Modifier.spec.ts
+++ b/test/03_Modifier.spec.ts
@@ -13,7 +13,7 @@ describe("Modifier", async () => {
     const avatar = await Avatar.deploy();
     const iAvatar = await hre.ethers.getContractAt("IAvatar", avatar.address);
     const Modifier = await hre.ethers.getContractFactory("TestModifier");
-    const modifier = await Modifier.deploy(iAvatar.address);
+    const modifier = await Modifier.deploy(iAvatar.address, iAvatar.address);
     await iAvatar.enableModule(modifier.address);
     // await modifier.enableModule(user1.address);
     const tx = {

--- a/test/04_Guard.spec.ts
+++ b/test/04_Guard.spec.ts
@@ -12,7 +12,7 @@ describe("Guardable", async () => {
     const avatar = await Avatar.deploy();
     const iAvatar = await hre.ethers.getContractAt("IAvatar", avatar.address);
     const Module = await hre.ethers.getContractFactory("TestModule");
-    const module = await Module.deploy(iAvatar.address);
+    const module = await Module.deploy(iAvatar.address, iAvatar.address);
     await avatar.enableModule(module.address);
     const Guard = await hre.ethers.getContractFactory("TestGuard");
     const guard = await Guard.deploy(module.address);
@@ -63,7 +63,7 @@ describe("BaseGuard", async () => {
     const avatar = await Avatar.deploy();
     const iAvatar = await hre.ethers.getContractAt("IAvatar", avatar.address);
     const Module = await hre.ethers.getContractFactory("TestModule");
-    const module = await Module.deploy(iAvatar.address);
+    const module = await Module.deploy(iAvatar.address, iAvatar.address);
     await avatar.enableModule(module.address);
     const Guard = await hre.ethers.getContractFactory("TestGuard");
     const guard = await Guard.deploy(module.address);

--- a/test/05_ModuleProxyFactory.spec.ts
+++ b/test/05_ModuleProxyFactory.spec.ts
@@ -23,10 +23,13 @@ describe("ModuleProxyFactory", async () => {
     moduleFactory = await ModuleProxyFactory.deploy();
 
     const MasterCopyModule = await ethers.getContractFactory("TestModule");
-    moduleMasterCopy = await MasterCopyModule.deploy(avatar.address);
+    moduleMasterCopy = await MasterCopyModule.deploy(
+      avatar.address,
+      avatar.address
+    );
     const encodedInitParams = new ethers.utils.AbiCoder().encode(
-      ["address"],
-      [avatar.address]
+      ["address", "address"],
+      [avatar.address, avatar.address]
     );
     initData = moduleMasterCopy.interface.encodeFunctionData("setUp", [
       encodedInitParams,
@@ -90,7 +93,7 @@ describe("ModuleProxyFactory", async () => {
       const newModule = await ethers.getContractAt("TestModule", moduleAddress);
 
       const isInitialized = await newModule.initialized();
-      expect(isInitialized).to.be.true
+      expect(isInitialized).to.be.true;
 
       const moduleAvatar = await newModule.avatar();
       expect(moduleAvatar).to.be.equal(avatarAddress);


### PR DESCRIPTION
We should separate the concept of `avatar` and the module that your passing messages to (`target`).
This would mean we'd have `owner`, `avatar`, and `target` as three separate variables.
In many cases, they would all be set to the same address. But there would be times when they should be different.

Take, for example, the Exit module.
Right now it assumes that the `owner` is the account that holds balances. But this may not always be the case. I could imagine situations where the a DAO wants to have some other contract as the owner of the Exit module, or wants to renounce ownership to make the contract immutable. Either case would break the exit module.

I propose this update:
`owner` is the address that can call `onlyOwner` functions.
`avatar` is the address that will ultimately execute the transaction (the Safe).
`target` is the next address in the chain; the address that this module will call `execModuleTransaction()` on.
