### PR TITLE
Chore: Initializer from OZ Upgradable implemented

### DIFF
--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -3,12 +3,11 @@
 /// @title Module Interface - A contract that can pass messages to a Module Manager contract if enabled by that contract.
 pragma solidity >=0.7.0 <0.9.0;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../interfaces/IAvatar.sol";
 import "../factory/FactoryFriendly.sol";
 import "../guard/Guardable.sol";
 
-abstract contract Module is OwnableUpgradeable, FactoryFriendly, Guardable {
+abstract contract Module is FactoryFriendly, Guardable {
     /// @dev Emitted each time the avatar is set.
     event AvatarSet(address indexed previousAvatar, address indexed newAvatar);
     /// @dev Emitted each time the Target is set.

--- a/contracts/factory/FactoryFriendly.sol
+++ b/contracts/factory/FactoryFriendly.sol
@@ -3,8 +3,8 @@
 /// @title Zodiac FactoryFriendly - A contract that allows other contracts to be initializable and pass bytes as arguments to define contract state
 pragma solidity >=0.7.0 <0.9.0;
 
-abstract contract FactoryFriendly {
-    bool public initialized;
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
+abstract contract FactoryFriendly is OwnableUpgradeable {
     function setUp(bytes memory initializeParams) public virtual;
 }

--- a/contracts/test/TestGuard.sol
+++ b/contracts/test/TestGuard.sol
@@ -10,7 +10,7 @@ import "@gnosis.pm/safe-contracts/contracts/interfaces/IERC165.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../core/Module.sol";
 
-contract TestGuard is FactoryFriendly, OwnableUpgradeable, BaseGuard {
+contract TestGuard is FactoryFriendly, BaseGuard {
     event PreChecked(bool checked);
     event PostChecked(bool checked);
 
@@ -53,10 +53,8 @@ contract TestGuard is FactoryFriendly, OwnableUpgradeable, BaseGuard {
         emit PostChecked(true);
     }
 
-    function setUp(bytes memory initializeParams) public override {
-        __Ownable_init();
+    function setUp(bytes memory initializeParams) public override initializer {
         address _module = abi.decode(initializeParams, (address));
         module = _module;
-        initialized = true;
     }
 }

--- a/contracts/test/TestModifier.sol
+++ b/contracts/test/TestModifier.sol
@@ -72,7 +72,7 @@ contract TestModifier is Modifier {
         );
     }
 
-    function setUp(bytes memory initializeParams) public override {
+    function setUp(bytes memory initializeParams) public override initializer {
         __Ownable_init();
         (address _avatar, address _target) = abi.decode(
             initializeParams,
@@ -80,6 +80,5 @@ contract TestModifier is Modifier {
         );
         avatar = _avatar;
         target = _target;
-        initialized = true;
     }
 }

--- a/contracts/test/TestModule.sol
+++ b/contracts/test/TestModule.sol
@@ -54,7 +54,7 @@ contract TestModule is Module {
         );
     }
 
-    function setUp(bytes memory initializeParams) public override {
+    function setUp(bytes memory initializeParams) public override initializer {
         __Ownable_init();
         (address _avatar, address _target) = abi.decode(
             initializeParams,
@@ -62,6 +62,5 @@ contract TestModule is Module {
         );
         avatar = _avatar;
         target = _target;
-        initialized = true;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "0.0.1-prealpha5",
+  "version": "0.0.1-prealpha7",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",
@@ -22,6 +22,10 @@
   },
   "directories": {
     "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gnosis/zodiac.git"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "0.0.1-prealpha1",
+  "version": "0.0.1-prealpha2",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",

--- a/src/factory/constants.ts
+++ b/src/factory/constants.ts
@@ -4,7 +4,7 @@ export const CONTRACT_ADDRESSES: Record<number, ContractAddresses> = {
   1: {
     realityETH: "",
     realityERC20: "",
-    amb: "",
+    bridge: "",
     delay: "",
     factory: "",
     exit: "",
@@ -12,23 +12,23 @@ export const CONTRACT_ADDRESSES: Record<number, ContractAddresses> = {
     circulatingSupply: "",
   },
   4: {
-    realityETH: "0x8f097901aE9A10Ff250A755eA1817f98aFF1eE5C",
-    realityERC20: "0x1Ca65cAc968436F1CF12f58D34E09e74D1cE2898",
-    amb: "0xf04e9c4aE09fCBb6DF20F0717B08eE298761C770",
-    delay: "0xb8215f0f08b204644507D706b544c541caD0ec16",
+    realityETH: "0x1cB7D83A87708B55C4ff3c0be5f48717c222B2e5",
+    realityERC20: "0xF669cfdf499e48e0B189206eED98C424F5f83dA7",
+    bridge: "0x8a53d2762f90711291c7168fDfC776fB3CFFf7ab",
+    delay: "0x753dAEDD9b4464D5AC0b46Ec5c54163678b5ecA3",
     factory: "0x569F2e024D0aD6bBfBd8135097DFa7D0641Ae79b",
     exit: "0x43b06634Cd6c9b55460a6aFCF412dCf6e9bcBB0E",
-    scopeGuard: "0x13d233567817E3a38B4082217E44CBa77c06Eb7f",
+    scopeGuard: "0xfDc921764b88A889F9BFa5Ba874f77607a63b832",
     circulatingSupply: "0xd7a85e7D0813F8440602E243Acb67df3CCeb5a60",
   },
   31337: {
-    realityETH: "0x8f097901aE9A10Ff250A755eA1817f98aFF1eE5C",
-    realityERC20: "",
-    amb: "0xf04e9c4aE09fCBb6DF20F0717B08eE298761C770",
-    delay: "0xb8215f0f08b204644507D706b544c541caD0ec16",
+    realityETH: "0x1cB7D83A87708B55C4ff3c0be5f48717c222B2e5",
+    realityERC20: "0xF669cfdf499e48e0B189206eED98C424F5f83dA7",
+    bridge: "0x8a53d2762f90711291c7168fDfC776fB3CFFf7ab",
+    delay: "0x753dAEDD9b4464D5AC0b46Ec5c54163678b5ecA3",
     factory: "0x569F2e024D0aD6bBfBd8135097DFa7D0641Ae79b",
     exit: "0x43b06634Cd6c9b55460a6aFCF412dCf6e9bcBB0E",
-    scopeGuard: "0x13d233567817E3a38B4082217E44CBa77c06Eb7f",
+    scopeGuard: "0xfDc921764b88A889F9BFa5Ba874f77607a63b832",
     circulatingSupply: "0xd7a85e7D0813F8440602E243Acb67df3CCeb5a60",
   }
 };
@@ -54,7 +54,7 @@ export const CONTRACT_ABIS: Record<keyof KnownContracts, string[]> = {
     `function setUp(bytes memory initParams) public`,
     `function initialized() public view returns (bool)`,
   ],
-  amb: [
+  bridge: [
     `function setAmb(address _amb) public`,
     `function setChainId(bytes32 _chainId) public`,
     `function setOwner(address _owner) public`,

--- a/src/factory/types.ts
+++ b/src/factory/types.ts
@@ -1,7 +1,7 @@
 export interface KnownContracts {
   realityETH: string;
   realityERC20: string;
-  amb: string;
+  bridge: string;
   delay: string;
   exit: string;
   scopeGuard: string;

--- a/test/05_ModuleProxyFactory.spec.ts
+++ b/test/05_ModuleProxyFactory.spec.ts
@@ -81,7 +81,7 @@ describe("ModuleProxyFactory", async () => {
   });
 
   describe("deployModule ", () => {
-    it("should deploy module and call init function ", async () => {
+    it("should deploy module", async () => {
       const deploymentTx = await moduleFactory.deployModule(
         moduleMasterCopy.address,
         initData,
@@ -91,9 +91,6 @@ describe("ModuleProxyFactory", async () => {
       const [moduleAddress] = transaction.events[1].args;
 
       const newModule = await ethers.getContractAt("TestModule", moduleAddress);
-
-      const isInitialized = await newModule.initialized();
-      expect(isInitialized).to.be.true;
 
       const moduleAvatar = await newModule.avatar();
       expect(moduleAvatar).to.be.equal(avatarAddress);


### PR DESCRIPTION
Changes proposed:
- `FactoryFriendly` does not has `initialized` variable anymore, instead we are making it extend from `Initialized` (via `OwnerUpgradable` contract)
- `Module` extends `OwnableUpgradable` via `FactoryFriendly`
- We don't check `initialized` variable anymore in tests because it's private in `Initialized` contract
- Version bumped