### PR TITLE
Import IERC165 from OZ rather than Safe contracts

### DIFF
--- a/contracts/guard/BaseGuard.sol
+++ b/contracts/guard/BaseGuard.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import "@gnosis.pm/safe-contracts/contracts/interfaces/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "../interfaces/IGuard.sol";
 
 abstract contract BaseGuard is IERC165 {

--- a/contracts/guard/Guardable.sol
+++ b/contracts/guard/Guardable.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@gnosis.pm/safe-contracts/contracts/interfaces/IERC165.sol";
 import "./BaseGuard.sol";
 
 /// @title Guardable - A contract that manages fallback calls made to this contract

--- a/contracts/test/TestGuard.sol
+++ b/contracts/test/TestGuard.sol
@@ -6,7 +6,6 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../guard/BaseGuard.sol";
 import "../factory/FactoryFriendly.sol";
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
-import "@gnosis.pm/safe-contracts/contracts/interfaces/IERC165.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../core/Module.sol";
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
     "@gnosis.pm/safe-contracts": "1.3.0",
+    "@openzeppelin/contracts": "^4.3.2",
     "@openzeppelin/contracts-upgradeable": "^4.2.0",
     "argv": "^0.0.2",
     "dotenv": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,6 +728,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.2.0.tgz#3b12d6fe9d51e563c8a6ae39c96c1d32c5d0fa4a"
   integrity sha512-vn0hoUqQzgOLzLZwFgh+w/D5hzJHX8F7X/7t/gZdSQYIEXMyGpXUwkr5A3eoAeoc42f/n7yDhwusvBmNknM41Q==
 
+"@openzeppelin/contracts@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
+  integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
Importing IERC165 from the safe contracts causes conflicts when modules import OZ libraries that import OZ's implementation of IERC165. Since it is more likely for Modules to import OZ than the Safe contracts, I propose that we import from OZ instead.

This PR also removes a few redundant imports.