### PR TITLE
Feat: Release versions action implemented

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Zodiac version release
+name: Version release
 
 on:
   release:
@@ -18,6 +18,8 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn
       - run: yarn build
+      - run: yarn build:factory
+      - run: yarn lint
       - run: yarn coverage
 
   publish-npm:
@@ -27,8 +29,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
+      - run: yarn
+      - run: yarn build
+      - run: yarn build:factory
       - run: yarn release
         env:
           NODE_AUTH_TOKEN: ${{secrets.PUBLISH_NPM_TOKEN}}
@@ -40,10 +45,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://npm.pkg.github.com/
-          scope: '@cbrzn'
-      - run: echo registry=https://npm.pkg.github.com/cbrzn >> .npmrc
+          scope: '@gnosis.pm'
+      - run: yarn
+      - run: yarn build
+      - run: yarn build:factory
+      - run: echo registry=https://npm.pkg.github.com/gnosis.pm >> .npmrc
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.PUBLISH_GITHUB_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Zodiac version release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn
+      - run: yarn build
+      - run: yarn coverage
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn release
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PUBLISH_NPM_TOKEN}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://npm.pkg.github.com/
+          scope: '@cbrzn'
+      - run: echo registry=https://npm.pkg.github.com/cbrzn >> .npmrc
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PUBLISH_GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
NOTE: In order to make this CI work we need to secrets key `PUBLISH_GITHUB_TOKEN` AND `PUBLISH_NPM_TOKEN`

Currently, in order to release new versions, it has to be done manually, in both Github and NPM; with this PR I aim to automate this process, by creating a Github Action which takes care of both releases when pushing a tag into Gh and creating a release on the repo (https://github.com/gnosis/zodiac/tags)

Now the steps to release a new version are the following:
- Create a tag locally (i.e: `git tag v0.0.1`)
- Push the tag (i.e: `git push origin v0.0.1`)

This will draft a new release in the repository, but it won't run the workflow yet. Go to your https://github.com/gnosis/zodiac/tags. You'll see the tag you just pushed at the top of the list.

Click on the tag, then click the "Edit tag" button. Enter some details about the release, then click the green "Publish release" button. Once the release is published, the package publishing workflow should begin. To verify this, go to the "Actions" tab of your repository. You should see the "Version release" workflow running.

For more details check this tutorial: https://dev.to/joeattardi/how-to-publish-an-npm-package-to-npm-and-github-package-registry-simultaneously-using-github-actions-213a (Is the one that I followed)