### PR TITLE
Feat: Pass msg.sender to guard

### DIFF
--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -103,7 +103,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 address(0),
                 payable(0),
                 bytes("0x"),
-                address(0)
+                msg.sender
             );
         }
         (success, returnData) = IAvatar(target)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
Currently the Module abstraction defining the Guards msgSender parameter of `checkTransaction` is hard coded to the ZERO address. Simply passing the sender a long to Guard contracts can open up the design space for Guards, enabling them to be able to scope certain permissions based on the account interacting with the module.

Security Considerations:

Allowing Modules to pass `msg.sender` to the guards allows guards to create permission bypasses based per account, not just per Module. If implemented or used incorrectly an account might gain access to the safe that was unexpected.

On the other hand this creates more flexibility for guards and safety accounts can be added that have total permission in the case of incorrectly scoping a Module that is the only access to the safe. 

In general I don't feel this changes much of the security assumptions of Modules or Guards.  