### PR TITLE
Make it possible to create deployment transactions for "unknown modules"

### DIFF
--- a/src/factory/README.md
+++ b/src/factory/README.md
@@ -34,11 +34,11 @@ This method is menthe for deploying contracts that is available in `./constants.
 }
 ```
 
-### 2. Deploy and set up an unknown module
+### 2. Deploy and set up an custom module
 
 This method is similar to `deployAndSetUpModule`. However it deals with the deployment of contracts that is NOT available in `./constants.ts`.
 
-- Interface: `deployAndSetUpUnknownModule(masterCopyAddress, abi, args, provider, chainId)`
+- Interface: `deployAndSetUpCustomModule(masterCopyAddress, abi, args, provider, chainId)`
 - Arguments:
   - `masterCopyAddress`: The address of the module to be deployed
   - `abi`: The ABI of the module to be deployed

--- a/src/factory/README.md
+++ b/src/factory/README.md
@@ -1,20 +1,22 @@
 # Module Factory
 
-The purpose of the Module Factory is to make the deployment of Safe Modules easier. 
-Applying the Minimal Proxy Pattern, this module reduces the gas cost and simplifies the track of deployed modules. 
-The Minimal Proxy Pattern has been used because the modules do not need to be upgradeable since a safe can deploy a new one. 
+The purpose of the Module Factory is to make the deployment of Safe Modules easier.
+Applying the Minimal Proxy Pattern, this module reduces the gas cost and simplifies the track of deployed modules.
+The Minimal Proxy Pattern has been used because the modules do not need to be upgradeable since a safe can deploy a new one.
 It's worth mentioning that it costs roughly 5k additional gas for each transaction when using a proxy.
 Thus, after a certain number of transactions (~700) it would likely be cheaper to deploy the module from the constructor rather than the proxy.
 
-There's also a JS API, allowing the developers to interact with the ProxyFactory Contract more easily. 
-You can check the factory file to see more details, it consists of 4 methods, described individually in the following sections:
+There's also a JS API, allowing the developers to interact with the ProxyFactory Contract more easily.
+You can check the factory file to see more details, it consists of 5 methods, described individually in the following sections:
 
-### 1. Deploy and set up module
+### 1. Deploy and set up a known module
+
+This method is menthe for deploying contracts that is available in `./constants.ts`.
 
 - Interface: `deployAndSetUpModule(moduleName, args, provider, chainId)`
 - Arguments:
   - `moduleName`: Name of the module to be deployed, note that it needs to exist as a key in the [CONTRACT_ADDRESSES](./constants.ts#L3-L12) object
-  - `args`: An object with two attributes: `value` and `types` 
+  - `args`: An object with two attributes: `value` and `types`
     - In `value` it expects an array of the arguments of the `setUp` function of the module to deploy
     - In `types` it expects an array of the types of every value
   - `provider`: Ethereum provider, expects an instance of `JsonRpcProvider` from `ethers`
@@ -32,7 +34,33 @@ You can check the factory file to see more details, it consists of 4 methods, de
 }
 ```
 
-### 2. Calculate new module address
+### 2. Deploy and set up an unknown module
+
+This method is similar to `deployAndSetUpModule`. However it deals with the deployment of contracts that is NOT available in `./constants.ts`.
+
+- Interface: `deployAndSetUpUnknownModule(masterCopyAddress, abi, args, provider, chainId)`
+- Arguments:
+  - `masterCopyAddress`: The address of the module to be deployed
+  - `abi`: The ABI of the module to be deployed
+  - `args`: An object with two attributes: `value` and `types`
+    - In `value` it expects an array of the arguments of the `setUp` function of the module to deploy
+    - In `types` it expects an array of the types of every value
+  - `provider`: Ethereum provider, expects an instance of `JsonRpcProvider` from `ethers`
+  - `chainId`: Number of network to interact with
+- Returns: An object with the transaction built in order to be executed by the Safe, and the expected address of the new module, this will allow developers to batch the transaction of deployment + enable module on safe. Example:
+
+```json
+{
+  "transaction": {
+    "data": "0x",
+    "to": "0x",
+    "value": "0x" // 0 as BigNumber
+  },
+  "expectedModuleAddress": "0x"
+}
+```
+
+### 3. Calculate new module address
 
 - Interface: `calculateProxyAddress(factory, masterCopy, initData)`
 - Arguments:
@@ -41,7 +69,7 @@ You can check the factory file to see more details, it consists of 4 methods, de
   - `initData`: Encoded function data that is used to set up the module
 - Returns: A string with the expected address
 
-### 3. Get Module
+### 4. Get Module
 
 - Interface: `getModuleInstance(moduleName, address, provider)`
 - Arguments:
@@ -52,7 +80,7 @@ You can check the factory file to see more details, it consists of 4 methods, de
 
 - Returns: A Contract instance of the Module
 
-### 4. Get Factory and Master Copy
+### 5. Get Factory and Master Copy
 
 - Interface: `getFactoryAndMasterCopy(moduleName, provider, chainId)`
 - Arguments:
@@ -76,5 +104,3 @@ will have the same address in supported networks, you can check which networks a
 
 [Singleton factory](https://eips.ethereum.org/EIPS/eip-2470) is used to deploy the Module Factory, if you want to deploy it
 into a not supported chain, you will need to use the [`singleton-deployment` script file](./singleton-deployment.ts)
-
-

--- a/src/factory/__tests__/index.spec.ts
+++ b/src/factory/__tests__/index.spec.ts
@@ -3,9 +3,11 @@ import { Contract } from "ethers";
 import { expect } from "chai";
 import {
   deployAndSetUpModule,
+  deployAndSetUpUnknownModule,
   getModuleInstance,
   getFactoryAndMasterCopy,
 } from "../factory";
+import { CONTRACT_ADDRESSES, CONTRACT_ABIS } from "../constants";
 
 import "@nomiclabs/hardhat-ethers";
 import { KnownContracts } from "../types";
@@ -53,6 +55,59 @@ describe("Factory JS functions ", () => {
     const { transaction: deployTx, expectedModuleAddress } =
       await deployAndSetUpModule(
         KnownContracts.REALITY_ETH,
+        args,
+        provider,
+        chainId,
+        saltNonce
+      );
+
+    const transaction = await signer.sendTransaction(deployTx);
+
+    const receipt = await transaction.wait();
+    expect(receipt.transactionHash).to.be.a("string");
+    expect(receipt.status).to.be.eq(1);
+    expect(expectedModuleAddress).to.a("string");
+    newModuleAddress = expectedModuleAddress;
+  });
+
+  it("should execute transaction and retrieve expected address when providing the address and ABI directly", async () => {
+    const [signer] = await ethers.getSigners();
+    const args = {
+      values: [
+        AddressOne,
+        AddressOne,
+        AddressOne,
+        100,
+        180,
+        2000,
+        100000000,
+        1,
+      ],
+      types: [
+        "address",
+        "address",
+        "address",
+        "uint32",
+        "uint32",
+        "uint32",
+        "uint256",
+        "uint256",
+      ],
+    };
+
+    const { factory, module } = getFactoryAndMasterCopy(
+      KnownContracts.REALITY_ETH,
+      provider,
+      chainId
+    );
+    const chainContracts = CONTRACT_ADDRESSES[chainId];
+    const masterCopyAddress = chainContracts[KnownContracts.REALITY_ETH];
+    const abi = CONTRACT_ABIS[KnownContracts.REALITY_ETH];
+
+    const { transaction: deployTx, expectedModuleAddress } =
+      await deployAndSetUpUnknownModule(
+        masterCopyAddress,
+        abi,
         args,
         provider,
         chainId,

--- a/src/factory/__tests__/index.spec.ts
+++ b/src/factory/__tests__/index.spec.ts
@@ -95,11 +95,6 @@ describe("Factory JS functions ", () => {
       ],
     };
 
-    const { factory, module } = getFactoryAndMasterCopy(
-      KnownContracts.REALITY_ETH,
-      provider,
-      chainId
-    );
     const chainContracts = CONTRACT_ADDRESSES[chainId];
     const masterCopyAddress = chainContracts[KnownContracts.REALITY_ETH];
     const abi = CONTRACT_ABIS[KnownContracts.REALITY_ETH];

--- a/src/factory/__tests__/index.spec.ts
+++ b/src/factory/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import { Contract } from "ethers";
 import { expect } from "chai";
 import {
   deployAndSetUpModule,
-  deployAndSetUpUnknownModule,
+  deployAndSetUpCustomModule,
   getModuleInstance,
   getFactoryAndMasterCopy,
 } from "../factory";
@@ -100,7 +100,7 @@ describe("Factory JS functions ", () => {
     const abi = CONTRACT_ABIS[KnownContracts.REALITY_ETH];
 
     const { transaction: deployTx, expectedModuleAddress } =
-      await deployAndSetUpUnknownModule(
+      await deployAndSetUpCustomModule(
         masterCopyAddress,
         abi,
         args,

--- a/src/factory/factory.ts
+++ b/src/factory/factory.ts
@@ -22,7 +22,7 @@ export const deployAndSetUpModule = (
   return getDeployAndSetupTx(factory, module, args, saltNonce);
 };
 
-export const deployAndSetUpUnknownModule = (
+export const deployAndSetUpCustomModule = (
   masterCopyAddress: string,
   abi: ABI,
   setupArgs: {

--- a/src/factory/factory.ts
+++ b/src/factory/factory.ts
@@ -1,4 +1,5 @@
 import { ethers, Contract, Signer, BigNumber } from "ethers";
+import { ABI } from "hardhat-deploy/dist/types";
 
 import { CONTRACT_ADDRESSES, CONTRACT_ABIS } from "./constants";
 import { KnownContracts } from "./types";
@@ -18,7 +19,37 @@ export const deployAndSetUpModule = (
     provider,
     chainId
   );
+  return getDeployAndSetupTx(factory, module, args, saltNonce);
+};
 
+export const deployAndSetUpUnknownModule = (
+  masterCopyAddress: string,
+  abi: ABI,
+  setupArgs: {
+    types: Array<string>;
+    values: Array<any>;
+  },
+  provider: ethers.providers.JsonRpcProvider,
+  chainId: number,
+  saltNonce: string
+) => {
+  const chainContracts = CONTRACT_ADDRESSES[chainId];
+  const factoryAddress = chainContracts.factory;
+  const factory = new Contract(factoryAddress, CONTRACT_ABIS.factory, provider);
+  const module = new Contract(masterCopyAddress, abi, provider);
+
+  return getDeployAndSetupTx(factory, module, setupArgs, saltNonce);
+};
+
+const getDeployAndSetupTx = (
+  factory: ethers.Contract,
+  module: ethers.Contract,
+  args: {
+    types: Array<string>;
+    values: Array<any>;
+  },
+  saltNonce: string
+) => {
   const encodedInitParams = ethers.utils.defaultAbiCoder.encode(
     args.types,
     args.values


### PR DESCRIPTION
Adds an external `deployAndSetUpUnknownModule` function to be used for deployments of modules developed by independent developers and therefore not a part of the known modules.

Closes #45