### PR TITLE
bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
This PR bumps the version in package.json.

We should really make a workflow that updates the version in package.json to whatever the version tag is when we publish a github release.