### PR TITLE
remove mod guard from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ contract MyModule is Module {
 
 
 #### Guards
-- **[Mod](https://github.com/gnosis/zodiac-guard-mod)** (developed by [Gnosis Guild](https://twitter.com/gnosisguild)): This guard allows an avatar to prevent the removal of a given module. For example, a DAO might have it's governance contracts enabled as a module to a Gnosis Safe, in parallel with some multisig signers. This guard could be used to prevent the multisig signers from removing the DAO's governance contracts as a module.
 - **[Scope](https://github.com/gnosis/zodiac-guard-scope)** (developed by [Gnosis Guild](https://twitter.com/gnosisguild)): This guard allows an avatar to limit the scope of the addressable functions with which its owners can interact. This enables the avatar to define granular permissions for different control mechanisms.
 
 ## Support and Contributions


### PR DESCRIPTION
## Fix a bug

### Implementation

This PR removes the mod guard from our readme as it is currently under review and should not be recommended for use.