### PR TITLE
Add arbitrum and optimism support

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -34,7 +34,7 @@ if (PK) {
 }
 
 if (
-  ["rinkeby", "mainnet", "goerli", "ropsten"].includes(network) &&
+  ["mainnet", "goerli", "ropsten"].includes(network) &&
   INFURA_KEY === undefined
 ) {
   throw new Error(
@@ -56,10 +56,6 @@ export default {
     mainnet: {
       ...sharedNetworkConfig,
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
-    },
-    rinkeby: {
-      ...sharedNetworkConfig,
-      url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
     },
     ropsten: {
       ...sharedNetworkConfig,
@@ -84,6 +80,14 @@ export default {
     arbitrum: {
       ...sharedNetworkConfig,
       url: "https://arb1.arbitrum.io/rpc",
+    },
+    optimism: {
+      ...sharedNetworkConfig,
+      url: "https://mainnet.optimism.io",
+    },
+    avalanche: {
+      ...sharedNetworkConfig,
+      url: "https://rpc.ankr.com/avalanche",
     },
   },
   namedAccounts: {

--- a/src/factory/constants.ts
+++ b/src/factory/constants.ts
@@ -6,27 +6,28 @@ export enum SUPPORTED_NETWORKS {
   BinanceSmartChain = 56,
   GnosisChain = 100,
   Polygon = 137,
-  HardhatNetwork = 31337,
-  Mumbai = 80001,
+  Mumbai = 80001, // not supported yet
   ArbitrumOne = 42161,
   Optimism = 10,
+  Avalanche = 43114,
+  HardhatNetwork = 31337,
 }
 
 const MasterCopyAddresses: Record<KnownContracts, string> = {
-  [KnownContracts.META_GUARD]: "0xe2847462a574bfd43014d1c7BB6De5769C294691",
-  [KnownContracts.REALITY_ETH]: "0x72d453a685c27580acDFcF495830EB16B7E165f8",
-  [KnownContracts.REALITY_ERC20]: "0x6f628F0c3A3Ff75c39CF310901f10d79692Ed889",
-  [KnownContracts.BRIDGE]: "0x457042756F2B1056487173003D27f37644C119f3",
-  [KnownContracts.DELAY]: "0xeD2323128055cE9539c6C99e5d7EBF4CA44A2485",
-  [KnownContracts.FACTORY]: "0x00000000000DC7F163742Eb4aBEf650037b1f588",
-  [KnownContracts.EXIT_ERC20]: "0x33bCa41bda8A3983afbAd8fc8936Ce2Fb29121da",
-  [KnownContracts.EXIT_ERC721]: "0xD3579C14a4181EfC3DF35C3103D20823A8C8d718",
-  [KnownContracts.SCOPE_GUARD]: "0xfDc921764b88A889F9BFa5Ba874f77607a63b832",
+  [KnownContracts.META_GUARD]: "0xe2847462a574bfd43014d1c7BB6De5769C294691", // missing: optimism, arbitrum, bsc
+  [KnownContracts.REALITY_ETH]: "0x72d453a685c27580acDFcF495830EB16B7E165f8", // missing: optimism, arbitrum, mumbai
+  [KnownContracts.REALITY_ERC20]: "0x6f628F0c3A3Ff75c39CF310901f10d79692Ed889", // missing: optimism, arbitrum, mumbai
+  [KnownContracts.BRIDGE]: "0x457042756F2B1056487173003D27f37644C119f3", // missing: i
+  [KnownContracts.DELAY]: "0xeD2323128055cE9539c6C99e5d7EBF4CA44A2485", // missing: optimism, goerli, bsc
+  [KnownContracts.FACTORY]: "0x00000000000DC7F163742Eb4aBEf650037b1f588", // missing: optimism
+  [KnownContracts.EXIT_ERC20]: "0x33bCa41bda8A3983afbAd8fc8936Ce2Fb29121da", // missing: mumbai, optimism, arbitrum,
+  [KnownContracts.EXIT_ERC721]: "0xD3579C14a4181EfC3DF35C3103D20823A8C8d718", // missing: mumbai, arbitrum, optimism
+  [KnownContracts.SCOPE_GUARD]: "0xfDc921764b88A889F9BFa5Ba874f77607a63b832", // missing: goerli, bsc, mumbai, arbitrum, optimism
   [KnownContracts.CIRCULATING_SUPPLY_ERC20]:
-    "0xb50fab2e2892E3323A5300870C042B428B564FE3",
+    "0xb50fab2e2892E3323A5300870C042B428B564FE3", // missing: mumbai, arbitrum, optimism
   [KnownContracts.CIRCULATING_SUPPLY_ERC721]:
-    "0x71530ec830CBE363bab28F4EC52964a550C0AB1E",
-  [KnownContracts.ROLES]: "0x85388a8cd772b19a468F982Dc264C238856939C9",
+    "0x71530ec830CBE363bab28F4EC52964a550C0AB1E", // missing: mumbai, arbitrum, optimism
+  [KnownContracts.ROLES]: "0x85388a8cd772b19a468F982Dc264C238856939C9", // missing: mumbai, arbitrum, optimism
   tellor: "",
   optimisticGovernor: "",
 };
@@ -61,6 +62,7 @@ export const CONTRACT_ADDRESSES: Record<
   },
   [SUPPORTED_NETWORKS.ArbitrumOne]: { ...MasterCopyAddresses }, //TODO: figure out what to change
   [SUPPORTED_NETWORKS.Optimism]: { ...MasterCopyAddresses }, //TODO: figure out what to change
+  [SUPPORTED_NETWORKS.Avalanche]: { ...MasterCopyAddresses }, //TODO: figure out what to change
 };
 
 export const CONTRACT_ABIS: Record<KnownContracts, string[]> = {

--- a/src/factory/constants.ts
+++ b/src/factory/constants.ts
@@ -1,16 +1,16 @@
 import { KnownContracts } from "./types";
 
-/*
- * 1     - Mainnet
- * 4     - Rinkeby
- * 5     - Goerli
- * 56    - Binance smart chain
- * 100   - Gnosis chain (Previously xdai)
- * 137   - Polygon
- * 31337 - hardhat network
- * 80001 - Mumbai
- */
-export const SUPPORTED_NETWORKS = [1, 4, 56, 100, 137, 31337, 80001];
+export enum SUPPORTED_NETWORKS {
+  Mainnet = 1,
+  Goerli = 5,
+  BinanceSmartChain = 56,
+  GnosisChain = 100,
+  Polygon = 137,
+  HardhatNetwork = 31337,
+  Mumbai = 80001,
+  ArbitrumOne = 42161,
+  Optimism = 10,
+}
 
 const MasterCopyAddresses: Record<KnownContracts, string> = {
   [KnownContracts.META_GUARD]: "0xe2847462a574bfd43014d1c7BB6De5769C294691",
@@ -32,39 +32,35 @@ const MasterCopyAddresses: Record<KnownContracts, string> = {
 };
 
 export const CONTRACT_ADDRESSES: Record<
-  number,
+  SUPPORTED_NETWORKS,
   Record<KnownContracts, string>
 > = {
-  1: {
+  [SUPPORTED_NETWORKS.Mainnet]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0x7D5f5EaF541AC203Ee1424895b6997041C886FBE",
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
       "0x56C11dE61e249cbBf337027B53Ed3b1dFA8a4e6F",
   },
-  4: {
-    ...MasterCopyAddresses,
-    [KnownContracts.TELLOR]: "0x2b0bfeBCDFE2228cAbA56dfDE9F067643B357343",
-    [KnownContracts.OPTIMISTIC_GOVERNOR]:
-      "0x82C60B22Ee1A814a14122c7Bd78652Fbc3fD8CB2",
-  },
-  5: {
+  [SUPPORTED_NETWORKS.Goerli]: {
     ...MasterCopyAddresses,
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
       "0x1340229DCF6e0bed7D9c2356929987C2A720F836",
   },
-  56: { ...MasterCopyAddresses },
-  100: { ...MasterCopyAddresses },
-  137: {
+  [SUPPORTED_NETWORKS.BinanceSmartChain]: { ...MasterCopyAddresses },
+  [SUPPORTED_NETWORKS.GnosisChain]: { ...MasterCopyAddresses },
+  [SUPPORTED_NETWORKS.Polygon]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xEAB27A2Dc46431B96126f20bFC3197eD8247ed79",
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
       "0x923b1AfF7D67507A5Bdf528bD3086456FEba10cB",
   },
-  31337: { ...MasterCopyAddresses },
-  80001: {
+  [SUPPORTED_NETWORKS.HardhatNetwork]: { ...MasterCopyAddresses },
+  [SUPPORTED_NETWORKS.Mumbai]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xBCc265bDbc5a26D9279250b6e9CbD5527EEf4FAD",
   },
+  [SUPPORTED_NETWORKS.ArbitrumOne]: { ...MasterCopyAddresses }, //TODO: figure out what to change
+  [SUPPORTED_NETWORKS.Optimism]: { ...MasterCopyAddresses }, //TODO: figure out what to change
 };
 
 export const CONTRACT_ABIS: Record<KnownContracts, string[]> = {


### PR DESCRIPTION
It also includes:
- Fix some linting warnings.
- Turn chain id's into enums
- Remove Rinkeby

Note:
This adds network support to the app. But still, some contracts are not deployed on all chains. However, merging this should not hurt anything.