### PR TITLE
fix: failing script when adding as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format:sol": "prettier ./contracts/**/*.sol -w",
     "format:ts": "prettier ./src/**/*.ts ./test/**/*.ts ./*.ts -w",
     "generate:types": "typechain --target ethers-v5 --out-dir abi-typechain-types './src/abi/*.json'",
-    "postinstall": "yarn build && yarn generate:types",
+    "prepare": "yarn build && yarn generate:types",
     "prebuild:factory": "yarn generate:types",
     "prerelease": "yarn clean && yarn build && yarn clean:factory && yarn build:factory",
     "release": "yarn publish --access public",


### PR DESCRIPTION
The `postinstall` hook also runs when installing the package as a dependency, which will fail since we trigger solidity compilation etc.

`prepare` seems to be more suitable:

> prepare (since npm@4.0.0)
> 
> - Runs BEFORE the package is packed, i.e. during `npm publish` and `npm pack`
> - Runs on local `npm install` without any arguments
> - Runs AFTER `prepublish`, but BEFORE `prepublishOnly`

– https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts
