### PR TITLE
Fix getModuleFactoryAndMasterCopy ReturnType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",

--- a/src/factory/moduleDeployer.ts
+++ b/src/factory/moduleDeployer.ts
@@ -192,7 +192,7 @@ export const getModuleFactoryAndMasterCopy = <T extends KnownContracts>(
   const moduleFactory = ModuleProxyFactory__factory.connect(
     factoryAddress,
     provider
-  ) as ReturnType<typeof ContractFactories[T]["connect"]>;
+  );
 
   return {
     moduleFactory,


### PR DESCRIPTION
Removes an incorrect type cast. Connecting to typechain's generated ModuleProxyFactory already produces the correct type