### PR TITLE
Fix initcode is not always array and prevent incompatible hardhat and ethers verions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",
@@ -90,5 +90,9 @@
     "hardhat-change-network": "^0.0.7",
     "solc": "^0.8.17",
     "yargs": "^17.6.0"
+  },
+  "peerDependencies": {
+    "ethers": "^5.7.1",
+    "hardhat": "^2.12.0"
   }
 }

--- a/src/factory/contracts.ts
+++ b/src/factory/contracts.ts
@@ -141,7 +141,10 @@ export const ContractFactories = {
   [KnownContracts.CONNEXT]: factories.Connext__factory,
 };
 
-export const MasterCopyInitData: Record<KnownContracts, object> = {
+export const MasterCopyInitData: Record<
+  KnownContracts,
+  { initCode: string; salt: string }
+> = {
   [KnownContracts.META_GUARD]: {
     initCode: "",
     salt: "",

--- a/src/factory/deployModuleFactory.ts
+++ b/src/factory/deployModuleFactory.ts
@@ -28,10 +28,8 @@ export const deployModuleFactory = async (
     const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
     if (Factory.bytecode !== FactoryInitCode) {
       console.warn(
-        "WARNING: The ModuleProxyFactory init code from (src/factory/contracts.ts) " +
-          "MasterCopyInitData[KnownContracts.FACTORY].initCode does not match the init " +
-          "code of the contract code at contracts/factory/ModuleProxyFactory.sol. " +
-          "You are most likely the MasterCopyInitData[KnownContracts.FACTORY].initCode is outdated."
+        "The compiled ModuleProxyFactory (from src/factory/contracts.ts) is outdated, it does " +
+          "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCod"
       );
     }
   } catch (e) {

--- a/src/factory/deployModuleFactory.ts
+++ b/src/factory/deployModuleFactory.ts
@@ -29,7 +29,7 @@ export const deployModuleFactory = async (
     if (Factory.bytecode !== FactoryInitCode) {
       console.warn(
         "The compiled ModuleProxyFactory (from src/factory/contracts.ts) is outdated, it does " +
-          "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCod"
+          "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCode"
       );
     }
   } catch (e) {

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -1,4 +1,5 @@
 export * from "./moduleDeployer";
 export * from "./mastercopyDeployer";
+export * from "./deployModuleFactory";
 export * from "./types";
 export * from "./contracts";

--- a/src/factory/mastercopyDeployer.ts
+++ b/src/factory/mastercopyDeployer.ts
@@ -27,7 +27,7 @@ export const deployMastercopy = async (
 ): Promise<string> => {
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
 
-  if (deploymentTx.data == null || deploymentTx.data.length === 0) {
+  if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
   }
   return await deployMastercopyWithInitData(hre, deploymentTx.data, salt);
@@ -53,7 +53,7 @@ export const computeTargetAddress = async (
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
   const singletonFactory = await getSingletonFactory(hre);
 
-  if (deploymentTx.data == null || deploymentTx.data.length === 0) {
+  if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
   }
 

--- a/src/factory/mastercopyDeployer.ts
+++ b/src/factory/mastercopyDeployer.ts
@@ -27,10 +27,10 @@ export const deployMastercopy = async (
 ): Promise<string> => {
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
 
-  if (Array.isArray(deploymentTx.data) && deploymentTx.data.length > 0) {
-    return await deployMastercopyWithInitData(hre, deploymentTx.data, salt);
+  if (deploymentTx.data == null || deploymentTx.data.length === 0) {
+    throw new Error("Unable to create the deployment data (no init code).");
   }
-  throw new Error("Unable to create the deployment data (no init code).");
+  return await deployMastercopyWithInitData(hre, deploymentTx.data, salt);
 };
 
 /**
@@ -53,7 +53,7 @@ export const computeTargetAddress = async (
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
   const singletonFactory = await getSingletonFactory(hre);
 
-  if (!Array.isArray(deploymentTx.data) || deploymentTx.data.length === 0) {
+  if (deploymentTx.data == null || deploymentTx.data.length === 0) {
     throw new Error("Unable to create the deployment data (no init code).");
   }
 

--- a/src/factory/singletonFactory.ts
+++ b/src/factory/singletonFactory.ts
@@ -29,6 +29,9 @@ export const getSingletonFactory = async (
   if (
     (await hardhat.ethers.provider.getCode(singletonFactory.address)) === "0x"
   ) {
+    console.log(
+      "Singelton factory is not deployed on this chain. Deploying singleton factory..."
+    );
     // fund the singleton factory deployer account
     await deployer.sendTransaction({
       to: singletonDeployer,
@@ -49,6 +52,7 @@ export const getSingletonFactory = async (
         "Singleton factory could not be deployed to correct address, deployment haulted."
       );
     }
+    console.log("Singleton factory deployed to " + singletonFactory.address);
   }
   return singletonFactory;
 };

--- a/src/factory/singletonFactory.ts
+++ b/src/factory/singletonFactory.ts
@@ -30,7 +30,7 @@ export const getSingletonFactory = async (
     (await hardhat.ethers.provider.getCode(singletonFactory.address)) === "0x"
   ) {
     console.log(
-      "Singelton factory is not deployed on this chain. Deploying singleton factory..."
+      "Singleton factory is not deployed on this chain. Deploying singleton factory..."
     );
     // fund the singleton factory deployer account
     await deployer.sendTransaction({

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,9 +535,9 @@
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
 "@noble/hashes@~1.1.1":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.3.tgz#360afc77610e0a61f3417e497dcf36862e4f8111"
-  integrity sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.5.tgz#1a0377f3b9020efe2fae03290bd2a12140c95c11"
+  integrity sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==
 
 "@noble/secp256k1@1.6.3", "@noble/secp256k1@~1.6.0":
   version "1.6.3"
@@ -2306,9 +2306,9 @@ bech32@1.1.4:
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 bigint-crypto-utils@^3.0.23:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/bigint-crypto-utils/-/bigint-crypto-utils-3.1.7.tgz#c4c1b537c7c1ab7aadfaecf3edfd45416bf2c651"
-  integrity sha512-zpCQpIE2Oy5WIQpjC9iYZf8Uh9QqoS51ZCooAcNvzv1AQ3VWdT52D0ksr1+/faeK8HVIej1bxXcP75YcqH3KPA==
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/bigint-crypto-utils/-/bigint-crypto-utils-3.1.8.tgz#e2e0f40cf45488f9d7f0e32ff84152aa73819d5d"
+  integrity sha512-+VMV9Laq8pXLBKKKK49nOoq9bfR3j7NNQAtbA617a4nw9bVLo8rsqkKMBgM2AJWlNX9fEIyYaYX+d0laqYV4tw==
   dependencies:
     bigint-mod-arith "^3.1.0"
 
@@ -5272,9 +5272,9 @@ hardhat-deploy@^0.11.18:
     zksync-web3 "^0.8.1"
 
 hardhat@^2.12.0:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.12.2.tgz#6ae985007b20c1f381c6573799d66c1438c4c802"
-  integrity sha512-f3ZhzXy1uyQv0UXnAQ8GCBOWjzv++WJNb7bnm10SsyC3dB7vlPpsMWBNhq7aoRxKrNhX9tCev81KFV3i5BTeMQ==
+  version "2.12.4"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.12.4.tgz#e539ba58bee9ba1a1ced823bfdcec0b3c5a3e70f"
+  integrity sha512-rc9S2U/4M+77LxW1Kg7oqMMmjl81tzn5rNFARhbXKUA1am/nhfMJEujOjuKvt+ZGMiZ11PYSe8gyIpB/aRNDgw==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@metamask/eth-sig-util" "^4.0.0"
@@ -5563,9 +5563,9 @@ immediate@~3.2.3:
   integrity sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==
 
 immutable@^4.0.0-rc.12:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
-  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.2.1.tgz#8a4025691018c560a40c67e43d698f816edc44d4"
+  integrity sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -6916,9 +6916,9 @@ mocha@7.1.2:
     yargs-unparser "1.6.0"
 
 mocha@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.1.0.tgz#dbf1114b7c3f9d0ca5de3133906aea3dfc89ef7a"
-  integrity sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"


### PR DESCRIPTION
Fix bug: we assumed that the init code is always an array, but it can also be a string.

Fix: Make sure that compatible versions of hardhat and ethers are used.

Fix: Use preexisting initCode and salt for deploying the ModuleFactory.