### PR TITLE
Make package usable in browser env

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/parser": "^5.40.0",
     "chai": "^4.3.6",
     "debug": "^4.3.4",
+    "dotenv": "^16.0.3",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
@@ -67,32 +68,29 @@
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^7.1.5",
     "hardhat": "^2.12.0",
+    "hardhat-change-network": "^0.0.7",
     "hardhat-deploy": "^0.11.18",
     "husky": "^8.0.1",
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "^1.0.0-beta.24",
     "rimraf": "^3.0.2",
+    "solc": "^0.8.17",
     "solhint": "^3.3.7",
     "solhint-plugin-prettier": "^0.0.5",
     "solidity-coverage": "^0.8.2",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "yargs": "^17.6.0"
   },
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",
     "@gnosis.pm/safe-contracts": "1.3.0",
     "@openzeppelin/contracts": "^4.3.2",
     "@openzeppelin/contracts-upgradeable": "^4.2.0",
-    "argv": "^0.0.2",
-    "dotenv": "^16.0.3",
-    "ethers": "^5.7.1",
-    "hardhat-change-network": "^0.0.7",
-    "solc": "^0.8.17",
-    "yargs": "^17.6.0"
+    "ethers": "^5.7.1"
   },
   "peerDependencies": {
-    "ethers": "^5.7.1",
-    "hardhat": "^2.12.0"
+    "ethers": "^5.7.1"
   }
 }

--- a/src/factory/deployModuleFactory.ts
+++ b/src/factory/deployModuleFactory.ts
@@ -16,10 +16,10 @@ const FactorySalt = MasterCopyInitData[KnownContracts.FACTORY].salt;
  * @returns The address of the deployed Module Proxy Factory, or the zero address if it was already deployed
  */
 export const deployModuleFactory = async (
-  provider: ethers.providers.JsonRpcProvider
+  signer: ethers.providers.JsonRpcSigner
 ): Promise<string> => {
   console.log("Deploying the Module Proxy Factory...");
-  const singletonFactory = await getSingletonFactory(provider);
+  const singletonFactory = await getSingletonFactory(signer);
   console.log(
     "  Singleton factory used for deployment:",
     singletonFactory.address
@@ -50,7 +50,7 @@ export const deployModuleFactory = async (
     result.transactionHash
   );
 
-  if ((await provider.getCode(targetAddress)).length < 3) {
+  if ((await signer.provider.getCode(targetAddress)).length < 3) {
     // will return "0x" when there is no code
     throw new Error(
       "  \x1B[31m✘ Deployment unsuccessful: No code at target address.\x1B[0m"

--- a/src/factory/deployModuleFactory.ts
+++ b/src/factory/deployModuleFactory.ts
@@ -1,7 +1,4 @@
-import "hardhat-deploy";
-import "@nomiclabs/hardhat-ethers";
-import { constants as ethersConstants } from "ethers";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { constants as ethersConstants, ethers } from "ethers";
 import { MasterCopyInitData } from "./contracts";
 import { getSingletonFactory } from "./singletonFactory";
 import { KnownContracts } from "./types";
@@ -19,26 +16,14 @@ const FactorySalt = MasterCopyInitData[KnownContracts.FACTORY].salt;
  * @returns The address of the deployed Module Proxy Factory, or the zero address if it was already deployed
  */
 export const deployModuleFactory = async (
-  hre: HardhatRuntimeEnvironment
+  provider: ethers.providers.JsonRpcProvider
 ): Promise<string> => {
   console.log("Deploying the Module Proxy Factory...");
-  const singletonFactory = await getSingletonFactory(hre);
+  const singletonFactory = await getSingletonFactory(provider);
   console.log(
     "  Singleton factory used for deployment:",
     singletonFactory.address
   );
-
-  try {
-    const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
-    if (Factory.bytecode !== FactoryInitCode) {
-      console.warn(
-        "  The compiled Module Proxy Factory (from src/factory/contracts.ts) is outdated, it does " +
-          "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCode"
-      );
-    }
-  } catch (e) {
-    // This is expected when the zodiac package is imported as a package.
-  }
 
   const targetAddress = await singletonFactory.callStatic.deploy(
     FactoryInitCode,
@@ -65,7 +50,7 @@ export const deployModuleFactory = async (
     result.transactionHash
   );
 
-  if ((await hre.ethers.provider.getCode(targetAddress)).length < 3) {
+  if ((await provider.getCode(targetAddress)).length < 3) {
     // will return "0x" when there is no code
     throw new Error(
       "  \x1B[31m✘ Deployment unsuccessful: No code at target address.\x1B[0m"

--- a/src/factory/mastercopyDeployer.ts
+++ b/src/factory/mastercopyDeployer.ts
@@ -2,10 +2,9 @@ import {
   BytesLike,
   ContractFactory,
   constants as ethersConstants,
+  ethers,
 } from "ethers";
 import { keccak256, getCreate2Address, getAddress } from "ethers/lib/utils";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import assert from "node:assert";
 import { getSingletonFactory } from "./singletonFactory";
 
 const { AddressZero } = ethersConstants;
@@ -20,7 +19,7 @@ const { AddressZero } = ethersConstants;
  * @returns The address of the deployed module mastercopy or the zero address if it was already deployed
  */
 export const deployMastercopy = async (
-  hre: HardhatRuntimeEnvironment,
+  provider: ethers.providers.JsonRpcProvider,
   mastercopyContractFactory: ContractFactory,
   args: Array<any>,
   salt: string
@@ -30,7 +29,7 @@ export const deployMastercopy = async (
   if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
   }
-  return await deployMastercopyWithInitData(hre, deploymentTx.data, salt);
+  return await deployMastercopyWithInitData(provider, deploymentTx.data, salt);
 };
 
 /**
@@ -45,13 +44,13 @@ export const deployMastercopy = async (
  * }
  */
 export const computeTargetAddress = async (
-  hre: HardhatRuntimeEnvironment,
+  provider: ethers.providers.JsonRpcProvider,
   mastercopyContractFactory: ContractFactory,
   args: Array<any>,
   salt: string
 ): Promise<{ address: string; isDeployed: boolean }> => {
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
-  const singletonFactory = await getSingletonFactory(hre);
+  const singletonFactory = await getSingletonFactory(provider);
 
   if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
@@ -73,10 +72,11 @@ export const computeTargetAddress = async (
   );
 
   // Sanity check
-  assert(
-    computedAddress === targetAddress || targetAddress === AddressZero,
-    "The computed address does not match the target address and the target address is not 0x0."
-  );
+  if (computedAddress !== targetAddress && targetAddress !== AddressZero) {
+    throw new Error(
+      "The computed address does not match the target address and the target address is not 0x0."
+    );
+  }
 
   return {
     address: computedAddress,
@@ -85,11 +85,11 @@ export const computeTargetAddress = async (
 };
 
 export const deployMastercopyWithInitData = async (
-  hre: HardhatRuntimeEnvironment,
+  provider: ethers.providers.JsonRpcProvider,
   initCode: BytesLike,
   salt: string
 ): Promise<string> => {
-  const singletonFactory = await getSingletonFactory(hre);
+  const singletonFactory = await getSingletonFactory(provider);
 
   // throws if this for some reason is not a valid address
   const targetAddress = getAddress(
@@ -110,44 +110,33 @@ export const deployMastercopyWithInitData = async (
   }
 
   // Sanity check
-  assert.equal(
-    targetAddress,
-    computedTargetAddress,
-    "The computed address does not match the target address."
-  );
-
-  let deployData;
-  switch (hre.network.name) {
-    case "optimism":
-      deployData = await singletonFactory.deploy(initCode, salt, {
-        gasLimit: 6000000,
-      });
-      break;
-    case "arbitrum":
-      deployData = await singletonFactory.deploy(initCode, salt, {
-        gasLimit: 200000000,
-      });
-      break;
-    case "avalanche":
-      deployData = await singletonFactory.deploy(initCode, salt, {
-        gasLimit: 8000000,
-      });
-      break;
-    case "mumbai":
-      deployData = await singletonFactory.deploy(initCode, salt, {
-        gasLimit: 8000000,
-      });
-      break;
-    default:
-      deployData = await singletonFactory.deploy(initCode, salt, {
-        gasLimit: 10000000,
-      });
-      break;
+  if (targetAddress !== computedTargetAddress) {
+    throw new Error("The computed address does not match the target address.");
   }
 
-  await deployData.wait();
+  let gasLimit;
+  switch (provider.network.name) {
+    case "optimism":
+      gasLimit = 6000000;
+      break;
+    case "arbitrum":
+      gasLimit = 200000000;
+      break;
+    case "avalanche":
+      gasLimit = 8000000;
+      break;
+    case "mumbai":
+      gasLimit = 8000000;
+      break;
+    default:
+      gasLimit = 10000000;
+  }
+  const deployTx = await singletonFactory.deploy(initCode, salt, {
+    gasLimit,
+  });
+  await deployTx.wait();
 
-  if ((await hre.ethers.provider.getCode(targetAddress)).length > 2) {
+  if ((await provider.getCode(targetAddress)).length > 2) {
     console.log(
       `  \x1B[32m✔ Mastercopy deployed to:        ${targetAddress} 🎉\x1B[0m `
     );

--- a/src/factory/mastercopyDeployer.ts
+++ b/src/factory/mastercopyDeployer.ts
@@ -19,7 +19,7 @@ const { AddressZero } = ethersConstants;
  * @returns The address of the deployed module mastercopy or the zero address if it was already deployed
  */
 export const deployMastercopy = async (
-  provider: ethers.providers.JsonRpcProvider,
+  signer: ethers.providers.JsonRpcSigner,
   mastercopyContractFactory: ContractFactory,
   args: Array<any>,
   salt: string
@@ -29,7 +29,7 @@ export const deployMastercopy = async (
   if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
   }
-  return await deployMastercopyWithInitData(provider, deploymentTx.data, salt);
+  return await deployMastercopyWithInitData(signer, deploymentTx.data, salt);
 };
 
 /**
@@ -44,13 +44,13 @@ export const deployMastercopy = async (
  * }
  */
 export const computeTargetAddress = async (
-  provider: ethers.providers.JsonRpcProvider,
+  signer: ethers.providers.JsonRpcSigner,
   mastercopyContractFactory: ContractFactory,
   args: Array<any>,
   salt: string
 ): Promise<{ address: string; isDeployed: boolean }> => {
   const deploymentTx = mastercopyContractFactory.getDeployTransaction(...args);
-  const singletonFactory = await getSingletonFactory(provider);
+  const singletonFactory = await getSingletonFactory(signer);
 
   if (!deploymentTx.data) {
     throw new Error("Unable to create the deployment data (no init code).");
@@ -85,11 +85,11 @@ export const computeTargetAddress = async (
 };
 
 export const deployMastercopyWithInitData = async (
-  provider: ethers.providers.JsonRpcProvider,
+  signer: ethers.providers.JsonRpcSigner,
   initCode: BytesLike,
   salt: string
 ): Promise<string> => {
-  const singletonFactory = await getSingletonFactory(provider);
+  const singletonFactory = await getSingletonFactory(signer);
 
   // throws if this for some reason is not a valid address
   const targetAddress = getAddress(
@@ -115,7 +115,7 @@ export const deployMastercopyWithInitData = async (
   }
 
   let gasLimit;
-  switch (provider.network.name) {
+  switch (signer.provider.network.name) {
     case "optimism":
       gasLimit = 6000000;
       break;
@@ -136,7 +136,7 @@ export const deployMastercopyWithInitData = async (
   });
   await deployTx.wait();
 
-  if ((await provider.getCode(targetAddress)).length > 2) {
+  if ((await signer.provider.getCode(targetAddress)).length > 2) {
     console.log(
       `  \x1B[32m✔ Mastercopy deployed to:        ${targetAddress} 🎉\x1B[0m `
     );

--- a/src/factory/moduleDeployer.ts
+++ b/src/factory/moduleDeployer.ts
@@ -10,7 +10,7 @@ import {
 } from "./contracts";
 import { KnownContracts } from "./types";
 
-type ABI = any[];
+type ABI = any[] | readonly any[];
 
 type TxAndExpectedAddress = {
   transaction: {

--- a/src/factory/moduleDeployer.ts
+++ b/src/factory/moduleDeployer.ts
@@ -1,5 +1,5 @@
+import { Provider } from "@ethersproject/providers";
 import { ethers, Contract, Signer, BigNumber } from "ethers";
-import { ABI } from "hardhat-deploy/dist/types";
 import { ModuleProxyFactory__factory } from "../../abi-typechain-types";
 
 import {
@@ -9,6 +9,8 @@ import {
   ContractFactories,
 } from "./contracts";
 import { KnownContracts } from "./types";
+
+type ABI = any[];
 
 type TxAndExpectedAddress = {
   transaction: {
@@ -36,7 +38,7 @@ export const deployAndSetUpModule = (
     types: Array<string>;
     values: Array<any>;
   },
-  provider: ethers.providers.JsonRpcProvider,
+  provider: Provider,
   chainId: number,
   saltNonce: string
 ): TxAndExpectedAddress => {
@@ -73,7 +75,7 @@ export const deployAndSetUpCustomModule = (
     types: Array<string>;
     values: Array<any>;
   },
-  provider: ethers.providers.JsonRpcProvider,
+  provider: Provider,
   chainId: number,
   saltNonce: string
 ): TxAndExpectedAddress => {
@@ -163,7 +165,7 @@ export const calculateProxyAddress = (
 export const getModuleInstance = <T extends KnownContracts>(
   moduleName: T,
   moduleAddress: string,
-  provider: ethers.providers.JsonRpcProvider | Signer
+  provider: Provider | Signer
 ) => {
   const moduleIsNotSupported =
     !Object.keys(ContractFactories).includes(moduleName);
@@ -178,7 +180,7 @@ export const getModuleInstance = <T extends KnownContracts>(
 
 export const getModuleFactoryAndMasterCopy = <T extends KnownContracts>(
   moduleName: T,
-  provider: ethers.providers.JsonRpcProvider,
+  provider: Provider,
   chainId: SupportedNetworks
 ) => {
   const chainContracts = ContractAddresses[chainId as SupportedNetworks];

--- a/src/factory/singletonFactory.ts
+++ b/src/factory/singletonFactory.ts
@@ -14,34 +14,34 @@ const SingletonFactoryAddress = "0xce0042b868300000d44a59004da54a005ffdcf9f";
  * @returns Singleton Factory contract
  */
 export const getSingletonFactory = async (
-  provider: ethers.providers.JsonRpcProvider
+  signer: ethers.providers.JsonRpcSigner
 ): Promise<Contract> => {
   const singletonDeployer = "0xBb6e024b9cFFACB947A71991E386681B1Cd1477D";
   const singletonFactory = new ethers.Contract(
     SingletonFactoryAddress,
     singletonFactoryAbi,
-    provider
+    signer
   );
 
   // check if singleton factory is deployed.
-  if ((await provider.getCode(singletonFactory.address)) === "0x") {
+  if ((await signer.provider.getCode(singletonFactory.address)) === "0x") {
     console.log(
       "Singleton factory is not deployed on this chain. Deploying singleton factory..."
     );
     // fund the singleton factory deployer account
-    await provider.getSigner().sendTransaction({
+    await signer.sendTransaction({
       to: singletonDeployer,
       value: ethers.utils.parseEther("0.0247"),
     });
 
     // deploy the singleton factory
     await (
-      await provider.sendTransaction(
+      await signer.provider.sendTransaction(
         "0xf9016c8085174876e8008303c4d88080b90154608060405234801561001057600080fd5b50610134806100206000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634af63f0214602d575b600080fd5b60cf60048036036040811015604157600080fd5b810190602081018135640100000000811115605b57600080fd5b820183602082011115606c57600080fd5b80359060200191846001830284011164010000000083111715608d57600080fd5b91908080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929550509135925060eb915050565b604080516001600160a01b039092168252519081900360200190f35b6000818351602085016000f5939250505056fea26469706673582212206b44f8a82cb6b156bfcc3dc6aadd6df4eefd204bc928a4397fd15dacf6d5320564736f6c634300060200331b83247000822470"
       )
     ).wait();
 
-    if ((await provider.getCode(singletonFactory.address)) == "0x") {
+    if ((await signer.provider.getCode(singletonFactory.address)) == "0x") {
       throw Error(
         "Singleton factory could not be deployed to correct address, deployment haulted."
       );

--- a/src/factory/singletonFactory.ts
+++ b/src/factory/singletonFactory.ts
@@ -1,5 +1,5 @@
-import { Contract } from "ethers";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { Contract, ethers } from "ethers";
+
 const singletonFactoryAbi = [
   "function deploy(bytes memory _initCode, bytes32 _salt) public returns (address payable createdContract)",
 ];
@@ -14,40 +14,34 @@ const SingletonFactoryAddress = "0xce0042b868300000d44a59004da54a005ffdcf9f";
  * @returns Singleton Factory contract
  */
 export const getSingletonFactory = async (
-  hardhat: HardhatRuntimeEnvironment
+  provider: ethers.providers.JsonRpcProvider
 ): Promise<Contract> => {
-  const [deployer] = await hardhat.ethers.getSigners();
-
   const singletonDeployer = "0xBb6e024b9cFFACB947A71991E386681B1Cd1477D";
-  const singletonFactory = new hardhat.ethers.Contract(
+  const singletonFactory = new ethers.Contract(
     SingletonFactoryAddress,
     singletonFactoryAbi,
-    deployer
+    provider
   );
 
   // check if singleton factory is deployed.
-  if (
-    (await hardhat.ethers.provider.getCode(singletonFactory.address)) === "0x"
-  ) {
+  if ((await provider.getCode(singletonFactory.address)) === "0x") {
     console.log(
       "Singleton factory is not deployed on this chain. Deploying singleton factory..."
     );
     // fund the singleton factory deployer account
-    await deployer.sendTransaction({
+    await provider.getSigner().sendTransaction({
       to: singletonDeployer,
-      value: hardhat.ethers.utils.parseEther("0.0247"),
+      value: ethers.utils.parseEther("0.0247"),
     });
 
     // deploy the singleton factory
     await (
-      await hardhat.ethers.provider.sendTransaction(
+      await provider.sendTransaction(
         "0xf9016c8085174876e8008303c4d88080b90154608060405234801561001057600080fd5b50610134806100206000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634af63f0214602d575b600080fd5b60cf60048036036040811015604157600080fd5b810190602081018135640100000000811115605b57600080fd5b820183602082011115606c57600080fd5b80359060200191846001830284011164010000000083111715608d57600080fd5b91908080601f016020809104026020016040519081016040528093929190818152602001838380828437600092019190915250929550509135925060eb915050565b604080516001600160a01b039092168252519081900360200190f35b6000818351602085016000f5939250505056fea26469706673582212206b44f8a82cb6b156bfcc3dc6aadd6df4eefd204bc928a4397fd15dacf6d5320564736f6c634300060200331b83247000822470"
       )
     ).wait();
 
-    if (
-      (await hardhat.ethers.provider.getCode(singletonFactory.address)) == "0x"
-    ) {
+    if ((await provider.getCode(singletonFactory.address)) == "0x") {
       throw Error(
         "Singleton factory could not be deployed to correct address, deployment haulted."
       );

--- a/src/tasks/deploy-replay.ts
+++ b/src/tasks/deploy-replay.ts
@@ -36,7 +36,7 @@ export const deploy = async (
           console.log(`    \x1B[4m${contracts[index]}\x1B[0m`);
           try {
             await deployMastercopyWithInitData(
-              hre,
+              hre.ethers.provider,
               initData.initCode,
               initData.salt
             );

--- a/src/tasks/deploy-replay.ts
+++ b/src/tasks/deploy-replay.ts
@@ -24,8 +24,8 @@ export const deploy = async (
 
     try {
       hre.changeNetwork(network);
-      const [wallet] = await hre.ethers.getSigners();
-      await hre.ethers.provider.getBalance(wallet.address);
+      const [deployer] = await hre.ethers.getSigners();
+      const signer = hre.ethers.provider.getSigner(deployer.address);
       for (let index = 0; index < contracts.length; index++) {
         const initData: InitData = MasterCopyInitData[contracts[index]];
         if (
@@ -36,7 +36,7 @@ export const deploy = async (
           console.log(`    \x1B[4m${contracts[index]}\x1B[0m`);
           try {
             await deployMastercopyWithInitData(
-              hre.ethers.provider,
+              signer,
               initData.initCode,
               initData.salt
             );

--- a/src/tasks/singleton-deployment.ts
+++ b/src/tasks/singleton-deployment.ts
@@ -1,9 +1,21 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { KnownContracts, MasterCopyInitData } from "../factory";
 import { deployModuleFactory } from "../factory/deployModuleFactory";
 
-export const deploy = async (_: null, hre: HardhatRuntimeEnvironment) =>
-  deployModuleFactory(hre);
+const FactoryInitCode = MasterCopyInitData[KnownContracts.FACTORY].initCode;
+
+export const deploy = async (_: null, hre: HardhatRuntimeEnvironment) => {
+  const Factory = await hre.ethers.getContractFactory("ModuleProxyFactory");
+  if (Factory.bytecode !== FactoryInitCode) {
+    console.warn(
+      "  The compiled Module Proxy Factory (from src/factory/contracts.ts) is outdated, it does " +
+        "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCode"
+    );
+  }
+  // const [deployer] = await hre.ethers.getSigners();
+  deployModuleFactory(hre.ethers.provider); // I'm assuming this provider uses deployer as signer, if this is not the case we will have to figure out how to make a JsonRpcProvider with deployer as signer
+};
 
 task(
   "singleton-deployment",

--- a/src/tasks/singleton-deployment.ts
+++ b/src/tasks/singleton-deployment.ts
@@ -13,8 +13,9 @@ export const deploy = async (_: null, hre: HardhatRuntimeEnvironment) => {
         "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCode"
     );
   }
+
   const [deployer] = await hre.ethers.getSigners();
-  deployModuleFactory(hre.ethers.provider.getSigner(deployer.address));
+  await deployModuleFactory(hre.ethers.provider.getSigner(deployer.address));
 };
 
 task(

--- a/src/tasks/singleton-deployment.ts
+++ b/src/tasks/singleton-deployment.ts
@@ -13,8 +13,8 @@ export const deploy = async (_: null, hre: HardhatRuntimeEnvironment) => {
         "not match the bytecode stored at MasterCopyInitData[KnownContracts.FACTORY].initCode"
     );
   }
-  // const [deployer] = await hre.ethers.getSigners();
-  deployModuleFactory(hre.ethers.provider); // I'm assuming this provider uses deployer as signer, if this is not the case we will have to figure out how to make a JsonRpcProvider with deployer as signer
+  const [deployer] = await hre.ethers.getSigners();
+  deployModuleFactory(hre.ethers.provider.getSigner(deployer.address));
 };
 
 task(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,11 +1536,6 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-argv@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
-  integrity sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==
-
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"


### PR DESCRIPTION
I wanted to use the zodiac package for deterministically deploying [club card contracts](https://github.com/gnosis/clubcard) but realized that the zodiac package dependencies are a bit of a mess. 

From some of our factory functions we relied on Hardhat APIs even so they really only require ethers. This PR reduces the set of runtime dependencies, in particular those that rely on node APIs.

@gnosis.pm/zodiac can now be used in browser environments without any hassle.

since the factory functions now take an ethers signer instead of the hardhat runtime env, we should bump the major for this release.