### PR TITLE
Adds a setupModules function to modifier.sol

### DIFF
--- a/contracts/core/Modifier.sol
+++ b/contracts/core/Modifier.sol
@@ -24,6 +24,9 @@ abstract contract Modifier is Module, IAvatar {
     /// `module` is already enabled.
     error AlreadyEnabledModule(address module);
 
+    /// @dev `setModules()` was already called.
+    error SetupModulesAlreadyCalled(address);
+
     /*
     --------------------------------------------------
     You must override at least one of following two virtual functions,
@@ -75,11 +78,10 @@ abstract contract Modifier is Module, IAvatar {
     /// @notice This can only be called by the owner.
     /// @param prevModule Module that pointed to the module to be removed in the linked list.
     /// @param module Module to be removed.
-    function disableModule(address prevModule, address module)
-        public
-        override
-        onlyOwner
-    {
+    function disableModule(
+        address prevModule,
+        address module
+    ) public override onlyOwner {
         if (module == address(0) || module == SENTINEL_MODULES)
             revert InvalidModule(module);
         if (modules[prevModule] != module) revert AlreadyDisabledModule(module);
@@ -102,12 +104,9 @@ abstract contract Modifier is Module, IAvatar {
 
     /// @dev Returns if an module is enabled
     /// @return True if the module is enabled
-    function isModuleEnabled(address _module)
-        public
-        view
-        override
-        returns (bool)
-    {
+    function isModuleEnabled(
+        address _module
+    ) public view override returns (bool) {
         return SENTINEL_MODULES != _module && modules[_module] != address(0);
     }
 
@@ -116,12 +115,10 @@ abstract contract Modifier is Module, IAvatar {
     /// @param pageSize Maximum number of modules that should be returned.
     /// @return array Array of modules.
     /// @return next Start of the next page.
-    function getModulesPaginated(address start, uint256 pageSize)
-        external
-        view
-        override
-        returns (address[] memory array, address next)
-    {
+    function getModulesPaginated(
+        address start,
+        uint256 pageSize
+    ) external view override returns (address[] memory array, address next) {
         /// Init array with max page size.
         array = new address[](pageSize);
 
@@ -143,5 +140,13 @@ abstract contract Modifier is Module, IAvatar {
         assembly {
             mstore(array, moduleCount)
         }
+    }
+
+    /// @dev Initializes the modules linked list.
+    /// @notice Should be called as part of the `setUp` / initializing function and can only be called once.
+    function setupModules() internal {
+        if (modules[SENTINEL_MODULES] != address(0))
+            revert SetupModulesAlreadyCalled(address(this));
+        modules[SENTINEL_MODULES] = SENTINEL_MODULES;
     }
 }


### PR DESCRIPTION
This PR adds the setupModules() function to `modifier.sol`.

Previously, this funciton was written into each contract inheriting `Modifier.sol` in a way that was both repetitive and redundant (since the check could never fail in those cases).