### PR TITLE
Improve: Update addresses for Optimistic Governor v2

### DIFF
--- a/src/abi/OptimisticGovernor.json
+++ b/src/abi/OptimisticGovernor.json
@@ -1,16 +1,55 @@
 [
   {
     "inputs": [
-      { "internalType": "address", "name": "_finder", "type": "address" },
-      { "internalType": "address", "name": "_owner", "type": "address" },
-      { "internalType": "address", "name": "_collateral", "type": "address" },
-      { "internalType": "uint256", "name": "_bondAmount", "type": "uint256" },
-      { "internalType": "string", "name": "_rules", "type": "string" },
-      { "internalType": "bytes32", "name": "_identifier", "type": "bytes32" },
-      { "internalType": "uint64", "name": "_liveness", "type": "uint64" }
+      {
+        "internalType": "address",
+        "name": "_finder",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateral",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_bondAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_rules",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_identifier",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_liveness",
+        "type": "uint64"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "guard_",
+        "type": "address"
+      }
+    ],
+    "name": "NotIERC165Compliant",
+    "type": "error"
   },
   {
     "anonymous": false,
@@ -88,6 +127,19 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "newOptimisticOracleV3",
+        "type": "address"
+      }
+    ],
+    "name": "OptimisticOracleChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "previousOwner",
         "type": "address"
       },
@@ -112,18 +164,31 @@
       },
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      },
-      {
-        "indexed": true,
         "internalType": "bytes32",
-        "name": "status",
+        "name": "assertionId",
         "type": "bytes32"
       }
     ],
     "name": "ProposalDeleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "proposalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ProposalExecuted",
     "type": "event"
   },
   {
@@ -142,7 +207,7 @@
         "type": "uint256"
       }
     ],
-    "name": "SetBond",
+    "name": "SetCollateralAndBond",
     "type": "event"
   },
   {
@@ -150,12 +215,12 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "contract IERC20",
-        "name": "collateral",
+        "internalType": "address",
+        "name": "escalationManager",
         "type": "address"
       }
     ],
-    "name": "SetCollateral",
+    "name": "SetEscalationManager",
     "type": "event"
   },
   {
@@ -188,7 +253,7 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
+        "indexed": false,
         "internalType": "string",
         "name": "rules",
         "type": "string"
@@ -227,6 +292,12 @@
       },
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
         "internalType": "uint256",
         "name": "transactionIndex",
         "type": "uint256"
@@ -251,17 +322,35 @@
         "type": "uint256"
       },
       {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
         "components": [
           {
             "components": [
-              { "internalType": "address", "name": "to", "type": "address" },
+              {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+              },
               {
                 "internalType": "enum Enum.Operation",
                 "name": "operation",
                 "type": "uint8"
               },
-              { "internalType": "uint256", "name": "value", "type": "uint256" },
-              { "internalType": "bytes", "name": "data", "type": "bytes" }
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              }
             ],
             "internalType": "struct OptimisticGovernor.Transaction[]",
             "name": "transactions",
@@ -292,6 +381,12 @@
       },
       {
         "indexed": false,
+        "internalType": "string",
+        "name": "rules",
+        "type": "string"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "challengeWindowEnds",
         "type": "uint256"
@@ -302,64 +397,52 @@
   },
   {
     "inputs": [],
-    "name": "PROPOSAL_HASH_KEY",
-    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "PROPOSAL_VALID_RESPONSE",
-    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "avatar",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "bondAmount",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "collateral",
+    "name": "EXPLANATION_KEY",
     "outputs": [
-      { "internalType": "contract IERC20", "name": "", "type": "address" }
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PROPOSAL_HASH_KEY",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RULES_KEY",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "_proposalHash", "type": "bytes32" }
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
     ],
-    "name": "deleteDisputedProposal",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "_proposalHash", "type": "bytes32" }
-    ],
-    "name": "deleteProposal",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "_proposalHash", "type": "bytes32" }
-    ],
-    "name": "deleteRejectedProposal",
+    "name": "assertionDisputedCallback",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -367,24 +450,138 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assertionIds",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "assertedTruthfully",
+        "type": "bool"
+      }
+    ],
+    "name": "assertionResolvedCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "avatar",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bondAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "collateral",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "deleteProposalOnUpgrade",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "escalationManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "components": [
-          { "internalType": "address", "name": "to", "type": "address" },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
           {
             "internalType": "enum Enum.Operation",
             "name": "operation",
             "type": "uint8"
           },
-          { "internalType": "uint256", "name": "value", "type": "uint256" },
-          { "internalType": "bytes", "name": "data", "type": "bytes" }
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct OptimisticGovernor.Transaction[]",
-        "name": "_transactions",
+        "name": "transactions",
         "type": "tuple[]"
       }
     ],
     "name": "executeProposal",
     "outputs": [],
-    "stateMutability": "payable",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -403,7 +600,13 @@
   {
     "inputs": [],
     "name": "getCurrentTime",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -411,7 +614,24 @@
     "inputs": [],
     "name": "getGuard",
     "outputs": [
-      { "internalType": "address", "name": "_guard", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_guard",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProposalBond",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -419,30 +639,48 @@
   {
     "inputs": [],
     "name": "guard",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "identifier",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "liveness",
-    "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "optimisticOracle",
+    "name": "optimisticOracleV3",
     "outputs": [
       {
-        "internalType": "contract OptimisticOracleV2Interface",
+        "internalType": "contract OptimisticOracleV3Interface",
         "name": "",
         "type": "address"
       }
@@ -453,14 +691,32 @@
   {
     "inputs": [],
     "name": "owner",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
     "name": "proposalHashes",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -468,20 +724,36 @@
     "inputs": [
       {
         "components": [
-          { "internalType": "address", "name": "to", "type": "address" },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
           {
             "internalType": "enum Enum.Operation",
             "name": "operation",
             "type": "uint8"
           },
-          { "internalType": "uint256", "name": "value", "type": "uint256" },
-          { "internalType": "bytes", "name": "data", "type": "bytes" }
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
         ],
         "internalType": "struct OptimisticGovernor.Transaction[]",
-        "name": "_transactions",
+        "name": "transactions",
         "type": "tuple[]"
       },
-      { "internalType": "bytes", "name": "_explanation", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "explanation",
+        "type": "bytes"
+      }
     ],
     "name": "proposeTransactions",
     "outputs": [],
@@ -498,13 +770,23 @@
   {
     "inputs": [],
     "name": "rules",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_avatar", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_avatar",
+        "type": "address"
+      }
     ],
     "name": "setAvatar",
     "outputs": [],
@@ -518,7 +800,11 @@
         "name": "_collateral",
         "type": "address"
       },
-      { "internalType": "uint256", "name": "_bondAmount", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_bondAmount",
+        "type": "uint256"
+      }
     ],
     "name": "setCollateralAndBond",
     "outputs": [],
@@ -527,7 +813,24 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_guard", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_escalationManager",
+        "type": "address"
+      }
+    ],
+    "name": "setEscalationManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_guard",
+        "type": "address"
+      }
     ],
     "name": "setGuard",
     "outputs": [],
@@ -536,7 +839,11 @@
   },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "_identifier", "type": "bytes32" }
+      {
+        "internalType": "bytes32",
+        "name": "_identifier",
+        "type": "bytes32"
+      }
     ],
     "name": "setIdentifier",
     "outputs": [],
@@ -545,7 +852,11 @@
   },
   {
     "inputs": [
-      { "internalType": "uint64", "name": "_liveness", "type": "uint64" }
+      {
+        "internalType": "uint64",
+        "name": "_liveness",
+        "type": "uint64"
+      }
     ],
     "name": "setLiveness",
     "outputs": [],
@@ -554,7 +865,11 @@
   },
   {
     "inputs": [
-      { "internalType": "string", "name": "_rules", "type": "string" }
+      {
+        "internalType": "string",
+        "name": "_rules",
+        "type": "string"
+      }
     ],
     "name": "setRules",
     "outputs": [],
@@ -563,7 +878,11 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_target", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_target",
+        "type": "address"
+      }
     ],
     "name": "setTarget",
     "outputs": [],
@@ -572,7 +891,11 @@
   },
   {
     "inputs": [
-      { "internalType": "bytes", "name": "initializeParams", "type": "bytes" }
+      {
+        "internalType": "bytes",
+        "name": "initializeParams",
+        "type": "bytes"
+      }
     ],
     "name": "setUp",
     "outputs": [],
@@ -589,13 +912,23 @@
   {
     "inputs": [],
     "name": "target",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "newOwner", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
     ],
     "name": "transferOwnership",
     "outputs": [],

--- a/src/deployments.json
+++ b/src/deployments.json
@@ -4,7 +4,7 @@
       "v1.0.0": "0xe2847462a574bfd43014d1c7BB6De5769C294691"
     },
     "optimisticGovernor": {
-      "v1.1.0": "0x61Ddf82AD2f9598ba4A0Be3c2369bFEd71B73cbA"
+      "v1.2.0": "0x28CeBFE94a03DbCA9d17143e9d2Bd1155DC26D5d"
     },
     "tellor": {
       "v2.0.0": "0xcc4C0ED5958770B5036189394360C33DDECf8414"
@@ -83,7 +83,7 @@
   },
   "5": {
     "optimisticGovernor": {
-      "v1.1.0": "0x8Baa1BCF4e3572ec49F7Ec8ab2F9571bdDbd39fc"
+      "v1.2.0": "0x07a7Be7AA4AaD42696A17e974486cb64A4daC47b"
     },
     "realityETH": {
       "v1.0.0": "0x72d453a685c27580acDFcF495830EB16B7E165f8"
@@ -192,6 +192,9 @@
     },
     "circulatingSupplyERC721": {
       "v1.1.0": "0x71530ec830CBE363bab28F4EC52964a550C0AB1E"
+    },
+    "optimisticGovernor": {
+      "v1.1.0": "0x972396Ab668cd11dc1F6321A5ae30c6A8d3759F0"
     }
   },
   "137": {
@@ -199,7 +202,7 @@
       "v1.0.0": "0xe2847462a574bfd43014d1c7BB6De5769C294691"
     },
     "optimisticGovernor": {
-      "v1.1.0": "0xeBa54EaaCe9B0b534099d3f52CB1fe9Ad714e98e"
+      "v1.2.0": "0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966"
     },
     "tellor": {
       "v2.0.0": "0xcc4C0ED5958770B5036189394360C33DDECf8414"

--- a/src/factory/contracts.ts
+++ b/src/factory/contracts.ts
@@ -68,34 +68,50 @@ export const ContractAddresses: Record<
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
-      "0x61Ddf82AD2f9598ba4A0Be3c2369bFEd71B73cbA",
+      "0x28CeBFE94a03DbCA9d17143e9d2Bd1155DC26D5d",
   },
   [SupportedNetworks.Goerli]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
-      "0x8Baa1BCF4e3572ec49F7Ec8ab2F9571bdDbd39fc",
+      "0x07a7Be7AA4AaD42696A17e974486cb64A4daC47b",
   },
-  [SupportedNetworks.BinanceSmartChain]: { ...MasterCopyAddresses,
+  [SupportedNetworks.BinanceSmartChain]: {
+    ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
   },
-  [SupportedNetworks.GnosisChain]: { ...MasterCopyAddresses,
-    [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414", 
+  [SupportedNetworks.GnosisChain]: {
+    ...MasterCopyAddresses,
+    [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
+    [KnownContracts.OPTIMISTIC_GOVERNOR]:
+      "0x972396Ab668cd11dc1F6321A5ae30c6A8d3759F0",
   },
   [SupportedNetworks.Polygon]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
     [KnownContracts.OPTIMISTIC_GOVERNOR]:
-      "0xeBa54EaaCe9B0b534099d3f52CB1fe9Ad714e98e",
+      "0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966",
   },
   [SupportedNetworks.HardhatNetwork]: { ...MasterCopyAddresses },
   [SupportedNetworks.Mumbai]: {
     ...MasterCopyAddresses,
     [KnownContracts.TELLOR]: "0xcc4C0ED5958770B5036189394360C33DDECf8414",
   },
-  [SupportedNetworks.ArbitrumOne]: { ...MasterCopyAddresses },
-  [SupportedNetworks.Optimism]: { ...MasterCopyAddresses },
-  [SupportedNetworks.Avalanche]: { ...MasterCopyAddresses },
+  [SupportedNetworks.ArbitrumOne]: {
+    ...MasterCopyAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]:
+      "0x30679ca4ea452d3df8a6c255a806e08810321763",
+  },
+  [SupportedNetworks.Optimism]: {
+    ...MasterCopyAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]:
+      "0x357fe84E438B3150d2F68AB9167bdb8f881f3b9A",
+  },
+  [SupportedNetworks.Avalanche]: {
+    ...MasterCopyAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]:
+      "0xEF8b46765ae805537053C59f826C3aD61924Db45",
+  },
 };
 
 export const ContractAbis: Record<KnownContracts, any> = {


### PR DESCRIPTION
### Implementation

This PR updates the optimistic governor contract addresses and ABI to use the v2 version of the Optimistic Governor contract.

See https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol for the updated contract.