### PR TITLE
bump version 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "3.3.2",
+  "version": "3.3.4",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",


### PR DESCRIPTION
versions 3.3.3 and 3.3.4 have not been published (GitHub Actions failed). we need to manually bump the version in package.json.