### PR TITLE
fix: incorrect typecast to zero bytes

### DIFF
--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -60,7 +60,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                bytes(""),
+                new bytes(0),
                 msg.sender
             );
             success = IAvatar(target).execTransactionFromModule(
@@ -107,7 +107,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                bytes(""),
+                new bytes(0),
                 msg.sender
             );
             (success, returnData) = IAvatar(target)

--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -60,7 +60,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                new bytes(0),
+                "",
                 msg.sender
             );
             success = IAvatar(target).execTransactionFromModule(
@@ -107,7 +107,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                new bytes(0),
+                "",
                 msg.sender
             );
             (success, returnData) = IAvatar(target)

--- a/contracts/core/Module.sol
+++ b/contracts/core/Module.sol
@@ -60,7 +60,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                bytes("0x"),
+                bytes(""),
                 msg.sender
             );
             success = IAvatar(target).execTransactionFromModule(
@@ -69,7 +69,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 data,
                 operation
             );
-            IGuard(currentGuard).checkAfterExecution(bytes32("0x"), success);
+            IGuard(currentGuard).checkAfterExecution(bytes32(""), success);
         } else {
             success = IAvatar(target).execTransactionFromModule(
                 to,
@@ -107,7 +107,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                 0,
                 address(0),
                 payable(0),
-                bytes("0x"),
+                bytes(""),
                 msg.sender
             );
             (success, returnData) = IAvatar(target)
@@ -117,7 +117,7 @@ abstract contract Module is FactoryFriendly, Guardable {
                     data,
                     operation
                 );
-            IGuard(currentGuard).checkAfterExecution(bytes32("0x"), success);
+            IGuard(currentGuard).checkAfterExecution(bytes32(""), success);
         } else {
             (success, returnData) = IAvatar(target)
                 .execTransactionFromModuleReturnData(


### PR DESCRIPTION
# fix: incorrect typecast to zero bytes

### Implementation

This PR fixes a bug where empty bytes was incorrectly typecast as `bytes("0x")`, rather than bytes("")`

### Additional Context

It's worth noting that the error is non impactful, other than a slight increase in the gas costs for `exec...` calls, since this data is presumably unused by the guards attached to modules.